### PR TITLE
fixed LF not being enforced on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
On Windows `autocrlf` is `true` by default so this makes sure we use LF everywhere