### PR TITLE
tsconfig.json: set target to ES2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "es5",
+    "target": "es2020",
   },
   "include": [
     "lib/**/*.js",


### PR DESCRIPTION
Even 2020 might be low for Node.js 14, but it surely is better than ES5 :)

~~BTW PRs should run CI.~~ NVM they do now :)