### PR TITLE
Add `stylistic/no-extra-semicolons` to config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -42,6 +42,7 @@ module.exports = {
     'stylistic/media-query-list-comma-space-before': 'never',
     'stylistic/no-empty-first-line': true,
     'stylistic/no-eol-whitespace': true,
+    'stylistic/no-extra-semicolons': true,
     'stylistic/no-missing-end-of-source-newline': true,
     'stylistic/number-leading-zero': 'always',
     'stylistic/number-no-trailing-zeros': true,


### PR DESCRIPTION
The `no-extra-semicolons` was previously included in `stylelint-config-recommended`, but removed in v10.0.1: https://github.com/stylelint/stylelint-config-recommended/pull/183

To make transitioning from `stylelint-config-recommended` to `stylelint-stylistic/config` easier, this PR adds the rule here. Note that this is technically a breaking change.