### PR TITLE
Copy over utils missing in stylelint 15.10.0

### DIFF
--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -1,13 +1,13 @@
 const { createPlugin } = require('stylelint')
 const atRuleParamIndex = require('stylelint/lib/utils/atRuleParamIndex')
 const isCustomMediaQuery = require('stylelint/lib/utils/isCustomMediaQuery')
-const isRangeContextMediaFeature = require('stylelint/lib/utils/isRangeContextMediaFeature')
 const isStandardSyntaxMediaFeatureName = require('stylelint/lib/utils/isStandardSyntaxMediaFeatureName')
 const mediaParser = require('postcss-media-query-parser').default
-const rangeContextNodeParser = require('stylelint/lib/rules/rangeContextNodeParser')
 const report = require('stylelint/lib/utils/report')
 const ruleMessages = require('stylelint/lib/utils/ruleMessages')
 const validateOptions = require('stylelint/lib/utils/validateOptions')
+const rangeContextNodeParser = require('../../utils/rangeContextNodeParser')
+const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature')
 
 const ruleName = 'stylistic/media-feature-name-case'
 

--- a/lib/utils/isRangeContextMediaFeature.js
+++ b/lib/utils/isRangeContextMediaFeature.js
@@ -1,0 +1,9 @@
+/**
+ * Check whether a media feature is a range context one
+ *
+ * @param {string} mediaFeature feature
+ * @return {boolean} If `true`, media feature is a range context one
+ */
+module.exports = function isRangeContextMediaFeature(mediaFeature) {
+  return mediaFeature.includes('=') || mediaFeature.includes('<') || mediaFeature.includes('>')
+}

--- a/lib/utils/rangeContextNodeParser.js
+++ b/lib/utils/rangeContextNodeParser.js
@@ -1,0 +1,57 @@
+const valueParser = require('postcss-value-parser')
+
+const { assert } = require('./validateTypes')
+
+const rangeOperators = new Set(['>=', '<=', '>', '<', '='])
+
+/**
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isRangeContextName(name) {
+  // When the node is like "(width > 10em)" or "(10em < width)"
+  // Regex is needed because the name can either be in the first or second position
+  return /^(?!--)\D/.test(name) || /^--./.test(name)
+}
+
+/**
+ * @typedef {{ value: string, sourceIndex: number }} RangeContextNode
+ *
+ * @param {import('postcss-media-query-parser').Node} node
+ * @returns {{ name: RangeContextNode, values: RangeContextNode[] }}
+ */
+module.exports = function rangeContextNodeParser(node) {
+  /** @type {import('postcss-value-parser').WordNode | undefined} */
+  let nameNode
+
+  /** @type {import('postcss-value-parser').WordNode[]} */
+  const valueNodes = []
+
+  valueParser(node.value).walk((valueNode) => {
+    if (valueNode.type !== 'word') return
+
+    if (rangeOperators.has(valueNode.value)) return
+
+    if (nameNode == null && isRangeContextName(valueNode.value)) {
+      nameNode = valueNode
+
+      return
+    }
+
+    valueNodes.push(valueNode)
+  })
+
+  assert(nameNode)
+
+  return {
+    name: {
+      value: nameNode.value,
+      sourceIndex: node.sourceIndex + nameNode.sourceIndex,
+    },
+
+    values: valueNodes.map((valueNode) => ({
+      value: valueNode.value,
+      sourceIndex: node.sourceIndex + valueNode.sourceIndex,
+    })),
+  }
+}

--- a/lib/utils/tests/isRangeContextMediaFeature.test.js
+++ b/lib/utils/tests/isRangeContextMediaFeature.test.js
@@ -1,0 +1,15 @@
+const isRangeContextMediaFeature = require('../isRangeContextMediaFeature')
+
+it('isRangeContextMediaFeature', () => {
+  expect(isRangeContextMediaFeature('(width = 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(width > 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(width < 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(HEIGHT >= 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(HEIGHT <= 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(5px > width < 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(5px => HEIGHT <= 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(5px > HEIGHT <= 10px)')).toBeTruthy()
+  expect(isRangeContextMediaFeature('(color)')).toBeFalsy()
+  expect(isRangeContextMediaFeature('(MONOCHROME)')).toBeFalsy()
+  expect(isRangeContextMediaFeature('(min-width: 10px)')).toBeFalsy()
+})

--- a/lib/utils/tests/validateTypes.test.js
+++ b/lib/utils/tests/validateTypes.test.js
@@ -1,0 +1,110 @@
+const {
+  isBoolean,
+  isFunction,
+  isNullish,
+  isNumber,
+  isObject,
+  isRegExp,
+  isString,
+  isPlainObject,
+} = require('../validateTypes')
+
+describe('isBoolean()', () => {
+  it('returns true when a boolean value is specified', () => {
+    expect(isBoolean(true)).toBe(true)
+  })
+
+  it('returns true when a Boolean object is specified', () => {
+    expect(isBoolean(new Boolean(true))).toBe(true) // eslint-disable-line no-new-wrappers
+  })
+
+  it('returns false when a boolean value is not specified', () => {
+    expect(isBoolean(null)).toBe(false)
+  })
+})
+
+describe('isFunction()', () => {
+  it('returns true when a function value is specified', () => {
+    expect(isFunction(() => 1)).toBe(true)
+  })
+
+  it('returns true when a Function object is specified', () => {
+    expect(isFunction(new Function())).toBe(true) // eslint-disable-line no-new-func
+  })
+
+  it('returns false when a function value is specified', () => {
+    expect(isFunction(null)).toBe(false)
+  })
+})
+
+describe('isNullish()', () => {
+  it('returns true when null is specified', () => {
+    expect(isNullish(null)).toBe(true)
+  })
+
+  it('returns true when undefined is specified', () => {
+    expect(isNullish(undefined)).toBe(true)
+  })
+
+  it('returns false when neither null nor undefined is specified', () => {
+    expect(isNullish('')).toBe(false)
+  })
+})
+
+describe('isNumber()', () => {
+  it('returns true when a number value is specified', () => {
+    expect(isNumber(1)).toBe(true)
+  })
+
+  it('returns true when a Number object is specified', () => {
+    expect(isNumber(new Number(1))).toBe(true) // eslint-disable-line no-new-wrappers
+  })
+
+  it('returns false when a number value is not specified', () => {
+    expect(isNumber(null)).toBe(false)
+  })
+})
+
+describe('isObject()', () => {
+  it('returns true when an object is specified', () => {
+    expect(isObject({})).toBe(true)
+  })
+
+  it('returns false when an object is not specified', () => {
+    expect(isObject(null)).toBe(false)
+  })
+})
+
+describe('isRegExp()', () => {
+  it('returns true when a regexp value is specified', () => {
+    expect(isRegExp(/a/)).toBe(true)
+  })
+
+  it('returns false when a regexp value is not specified', () => {
+    expect(isRegExp(null)).toBe(false)
+  })
+})
+
+describe('isString()', () => {
+  it('returns true when a string value is specified', () => {
+    expect(isString('')).toBe(true)
+  })
+
+  it('returns true when a String object is specified', () => {
+    expect(isString(new String(''))).toBe(true) // eslint-disable-line no-new-wrappers
+  })
+
+  it('returns false when a string value is not specified', () => {
+    expect(isString(null)).toBe(false)
+  })
+})
+
+describe('isPlainObject()', () => {
+  it('returns true when a plain object is specified', () => {
+    expect(isPlainObject({})).toBe(true)
+  })
+
+  it('returns false when a plain object is not specified', () => {
+    expect(isPlainObject(null)).toBe(false)
+  })
+})

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -1,0 +1,136 @@
+const { isPlainObject: _isPlainObject } = require('is-plain-object')
+
+/**
+ * Checks if the value is a boolean or a Boolean object.
+ * @param {unknown} value
+ * @returns {value is boolean}
+ */
+function isBoolean(value) {
+  return typeof value === 'boolean' || value instanceof Boolean
+}
+
+/**
+ * Checks if the value is a function or a Function object.
+ * @param {unknown} value
+ * @returns {value is Function}
+ */
+function isFunction(value) {
+  return typeof value === 'function' || value instanceof Function
+}
+
+/**
+ * Checks if the value is *nullish*.
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Nullish
+ * @param {unknown} value
+ * @returns {value is null | undefined}
+ */
+function isNullish(value) {
+  return value == null
+}
+
+/**
+ * Checks if the value is a number or a Number object.
+ * @param {unknown} value
+ * @returns {value is number}
+ */
+function isNumber(value) {
+  return typeof value === 'number' || value instanceof Number
+}
+
+/**
+ * Checks if the value is an object.
+ * @param {unknown} value
+ * @returns {value is object}
+ */
+function isObject(value) {
+  return value !== null && typeof value === 'object'
+}
+
+/**
+ * Checks if the value is a regular expression.
+ * @param {unknown} value
+ * @returns {value is RegExp}
+ */
+function isRegExp(value) {
+  return value instanceof RegExp
+}
+
+/**
+ * Checks if the value is a string or a String object.
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isString(value) {
+  return typeof value === 'string' || value instanceof String
+}
+
+/**
+ * Checks if the value is a plain object.
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isPlainObject(value) {
+  return _isPlainObject(value)
+}
+
+/**
+ * Assert that the value is truthy.
+ * @param {unknown} value
+ * @param {string} [message]
+ * @returns {asserts value}
+ */
+function assert(value, message = undefined) {
+  if (message) {
+    // eslint-disable-next-line no-console
+    console.assert(value, message)
+  } else {
+    // eslint-disable-next-line no-console
+    console.assert(value)
+  }
+}
+
+/**
+ * Assert that the value is a function or a Function object.
+ * @param {unknown} value
+ * @returns {asserts value is Function}
+ */
+function assertFunction(value) {
+  // eslint-disable-next-line no-console
+  console.assert(isFunction(value), `"${value}" must be a function`)
+}
+
+/**
+ * Assert that the value is a number or a Number object.
+ * @param {unknown} value
+ * @returns {asserts value is number}
+ */
+function assertNumber(value) {
+  // eslint-disable-next-line no-console
+  console.assert(isNumber(value), `"${value}" must be a number`)
+}
+
+/**
+ * Assert that the value is a string or a String object.
+ * @param {unknown} value
+ * @returns {asserts value is string}
+ */
+function assertString(value) {
+  // eslint-disable-next-line no-console
+  console.assert(isString(value), `"${value}" must be a string`)
+}
+
+module.exports = {
+  isBoolean,
+  isFunction,
+  isNullish,
+  isNumber,
+  isObject,
+  isRegExp,
+  isString,
+  isPlainObject,
+
+  assert,
+  assertFunction,
+  assertNumber,
+  assertString,
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "!dist/**/tests/*"
   ],
   "dependencies": {
+    "is-plain-object": "^5.0.0",
     "postcss": "^8.4.21",
     "postcss-media-query-parser": "^0.2.3",
     "postcss-value-parser": "^4.2.0",
@@ -49,7 +50,6 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
-    "is-plain-object": "^5.0.0",
     "jest": "^29.5.0",
     "jest-fail-on-console": "^3.1.1",
     "jest-preset-stylelint": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
+    "is-plain-object": "^5.0.0",
     "jest": "^29.5.0",
     "jest-fail-on-console": "^3.1.1",
     "jest-preset-stylelint": "^6.1.0",


### PR DESCRIPTION
This addresses the problem described in #12 by copying over the following files from stylelint 15.9.0.

* isRangeContextMediaFeature.js
* isRangeContextMediaFeature.test.js
* rangeContextNodeParser.js
* validateTypes.js
* validateTypes.test.js

This would get it working with 15.10.0 so that people are not barred from upgrading. Then future work could be done to move all the internal dependencies from stylelint to avoid this becoming a problem again.