### PR TITLE
fixed autofixing of `@charset` name by string-quotes rule

### DIFF
--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -187,9 +187,10 @@ const rule = (primary, secondaryOptions, context) => {
       }
 
       if (isAtRule(node) && node.name === 'charset') {
-        // allow @charset rules to have double quotes, in spite of the configuration
-        // TODO: @charset should always use double-quotes, see https://github.com/stylelint/stylelint/issues/2788
-        return
+        const hasValidQuotes = node.params.startsWith('"') && node.params.endsWith('"');
+
+        // pass through to the fixer only if the primary option is "double"
+        if (hasValidQuotes || correctQuote === "'") return;
       }
 
       valueParser(value).walk((valueNode) => {

--- a/lib/rules/string-quotes/tests/index.test.js
+++ b/lib/rules/string-quotes/tests/index.test.js
@@ -95,6 +95,13 @@ testRule({
       line: 1,
       column: 9,
     },
+    {
+      code: '@charset \'utf-8\'',
+      fixed: '@charset "utf-8"',
+      description: 'should be covered by a new at-charset-rule-no-invalid rule\n\
+                    see stylelint/stylelint#7492',
+      skip: true
+    },
   ],
 })
 
@@ -181,6 +188,13 @@ testRule({
       message: messages.expected('double'),
       line: 1,
       column: 9,
+    },
+    {
+      code: '@charset \'utf-8\'',
+      fixed: '@charset "utf-8"',
+      message: messages.expected('double'),
+      line: 1,
+      column: 10,
     },
   ],
 })


### PR DESCRIPTION
fixes #16

I chose not to fix `@charset 'utf-8';` if `"string-quotes": "single"` because that would be unexpected and not on scope with the rule.
see https://github.com/elirasza/stylelint-stylistic/pull/19/files#diff-c4836ee386f1e3186b5d6eb7c4eeb886a694cab5d0059b10f1c681331699ecd5R101-R102